### PR TITLE
ARCH-126 - Switch to using rubygems-version and properly parameterize

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       - image: circleci/ruby:2.6.2-stretch-node-browsers
         environment:
           BUNDLE_PATH: *bundle_path
-          BUNDLER_VERSION: 2.2.7
+          BUNDLER_VERSION: 2.2.9
           RAILS_ENV: test
           RACK_ENV: test
   working_directory: *working_path

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ circleci config pack src > orb.yml
 circleci orb validate orb.yml
 
 # For a mutable "dev" version, increment DEV_ORB_VERSION (below) and publish orb.yml.
-DEV_ORB_VERSION=dev:0.4.7
+DEV_ORB_VERSION=dev:0.4.8
 circleci orb publish orb.yml valimail/dependency-manager@$DEV_ORB_VERSION
 
 # For an immutable release, increment ORB_VERSION (below) and publish orb.yml.
 # Note: only GitHub admins of ValiMail can do this currently.
-ORB_VERSION=0.4.7
+ORB_VERSION=0.4.8
 circleci orb publish orb.yml valimail/dependency-manager@$ORB_VERSION
 
 # Update version for tests in .circleci/config.yml

--- a/orb.yml
+++ b/orb.yml
@@ -66,10 +66,6 @@ commands:
                 default: vendor/bundle
                 description: Path to store gems bundle
                 type: string
-            bundler-version:
-                default: 2.2.7
-                description: Which version of bundler to target for install
-                type: string
             cache-gems:
                 default: true
                 type: boolean
@@ -83,6 +79,10 @@ commands:
             restore-gems:
                 default: true
                 type: boolean
+            rubygems-version:
+                default: ""
+                description: Which version of Rubygems to target for install, empty is latest
+                type: string
             update-bundler:
                 default: true
                 type: boolean
@@ -91,7 +91,7 @@ commands:
                 condition: << parameters.update-bundler >>
                 steps:
                     - update-bundler:
-                        bundler-version: << parameters.bundler-version >>
+                        rubygems-version: << parameters.rubygems-version >>
             - when:
                 condition: << parameters.restore-gems >>
                 steps:
@@ -256,16 +256,14 @@ commands:
         description: |
             Update rubygems and bundler
         parameters:
-            bundler-version:
-                default: 2.2.7
-                description: Which version of bundler to target for install
+            rubygems-version:
+                default: ""
+                description: Which version of Rubygems to target for install, empty is latest
                 type: string
         steps:
             - run:
                 command: |
-                    export BUNDLER_VERSION=<< parameters.bundler-version >>
-                    sudo gem update --system
-                    sudo sh -c 'yes | gem update --force bundler'
+                    sudo gem update --system << parameters.rubygems-version >>
                 name: Update bundler
 description: |
     Restore, install, and cache dependencies like Ruby gems and JS packages.

--- a/src/commands/install-gems.yml
+++ b/src/commands/install-gems.yml
@@ -7,10 +7,10 @@ parameters:
     type: string
     default: vendor/bundle
 
-  bundler-version:
-    description: Which version of bundler to target for install
-    type: string
-    default: 2.2.7
+  rubygems-version:
+      default: ''
+      description: Which version of Rubygems to target for install, empty is latest
+      type: string
 
   cache-version:
     description: Version prefix to use in cache key
@@ -42,7 +42,7 @@ steps:
       condition: << parameters.update-bundler >>
       steps:
         - update-bundler:
-            bundler-version: << parameters.bundler-version >>
+            rubygems-version: << parameters.rubygems-version >>
 
   - when:
       condition: << parameters.restore-gems >>

--- a/src/commands/update-bundler.yml
+++ b/src/commands/update-bundler.yml
@@ -2,15 +2,13 @@ description: >
   Update rubygems and bundler
 
 parameters:
-  bundler-version:
-    description: Which version of bundler to target for install
-    type: string
-    default: 2.2.7
+  rubygems-version:
+      default: ''
+      description: Which version of Rubygems to target for install, empty is latest
+      type: string
 
 steps:
   - run:
       name: Update bundler
       command: |
-        export BUNDLER_VERSION=<< parameters.bundler-version >>
-        sudo gem update --system
-        sudo sh -c 'yes | gem update --force bundler'
+        sudo gem update --system << parameters.rubygems-version >>

--- a/tests/files/Gemfile.lock.example
+++ b/tests/files/Gemfile.lock.example
@@ -26,4 +26,4 @@ DEPENDENCIES
   fast_jsonapi
 
 BUNDLED WITH
-   2.2.7
+   2.2.9


### PR DESCRIPTION
This should allow us to update the CircleCI config files on our repos more robustly.  After this Orb is published we'll need to:

1. Update the dependency-manager orb version referenced in the CircleCI config to 0.4.8
2. Remove the extraneous `update-bundler` task under `install_required_software`
3. Pass in a parameter `rubygems-version` with value `3.2.9` under the `install-gems` task

That should lock us to Rubygems 3.2.9 / Bundler 2.2.9