### PR TITLE
orb dev 0.5.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ circleci config pack src > orb.yml
 circleci orb validate orb.yml
 
 # For a mutable "dev" version, increment DEV_ORB_VERSION (below) and publish orb.yml.
-DEV_ORB_VERSION=dev:0.5.16
+DEV_ORB_VERSION=dev:0.5.17
 circleci orb publish orb.yml valimail/dependency-manager@$DEV_ORB_VERSION
 
 # For an immutable release, increment ORB_VERSION (below) and publish orb.yml.
 # Note: only GitHub admins of ValiMail can do this currently.
-ORB_VERSION=0.5.16
+ORB_VERSION=0.5.17
 circleci orb publish orb.yml valimail/dependency-manager@$ORB_VERSION
 
 # Update version for tests in .circleci/config.yml

--- a/orb.yml
+++ b/orb.yml
@@ -53,7 +53,7 @@ commands:
             Cleanup old gems so they are not cached
         steps:
             - run:
-                command: bundle exec bundle clean
+                command: rm -rf ~/.bundle/cache/compact_index/gems* && bundle exec bundle clean --force
                 name: Remove old gems
     install-gems:
         description: |

--- a/orb.yml
+++ b/orb.yml
@@ -53,7 +53,7 @@ commands:
             Cleanup old gems so they are not cached
         steps:
             - run:
-                command: rm -rf ~/.bundle/cache/compact_index/gems* && bundle exec bundle clean --force
+                command: bundle exec bundle clean
                 name: Remove old gems
     install-gems:
         description: |


### PR DESCRIPTION
Your dev orb will expire in 90 days unless a new version is published on the label `dev:0.5.17`.
Please note that this is an open orb and is world-readable.
