### PR TITLE
[ADK-8276] Bump Orb dev version 0.5.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ circleci config pack src > orb.yml
 circleci orb validate orb.yml
 
 # For a mutable "dev" version, increment DEV_ORB_VERSION (below) and publish orb.yml.
-DEV_ORB_VERSION=dev:0.5.17
+DEV_ORB_VERSION=dev:0.5.18
 circleci orb publish orb.yml valimail/dependency-manager@$DEV_ORB_VERSION
 
 # For an immutable release, increment ORB_VERSION (below) and publish orb.yml.
 # Note: only GitHub admins of ValiMail can do this currently.
-ORB_VERSION=0.5.17
+ORB_VERSION=0.5.18
 circleci orb publish orb.yml valimail/dependency-manager@$ORB_VERSION
 
 # Update version for tests in .circleci/config.yml


### PR DESCRIPTION
## Ticket
https://valimail.atlassian.net/browse/ADK-8276

```
~/Sites/dependency-manager-orb  chore/update…rsion_0.5.18  circleci orb validate orb.yml                                                                                                                           ✔  11s  3.2.4   06:54:51
Orb at `orb.yml` is valid.

 ~/Sites/dependency-manager-orb  chore/update…rsion_0.5.18  DEV_ORB_VERSION=dev:0.5.18                                                                                                                                    ✔  3.2.4   06:55:26

 ~/Sites/dependency-manager-orb  chore/update…rsion_0.5.18  circleci orb publish orb.yml valimail/dependency-manager@$DEV_ORB_VERSION                                                                                     ✔  3.2.4   06:55:35
Once an orb is created it cannot be deleted. Orbs are semver compliant, and each published version is immutable. Publicly released orbs are potential dependencies for other projects.
Therefore, allowing orb deletion would make users susceptible to unexpected loss of functionality.
Orb `valimail/dependency-manager@dev:0.5.18` was published.
Note that your dev label `dev:0.5.18` can be overwritten by anyone in your organization.
Your dev orb will expire in 90 days unless a new version is published on the label `dev:0.5.18`.
Please note that this is an open orb and is world-readable.
```
https://app.circleci.com/pipelines/gh/ValiMail/auth_manager/64001
## Screenshots
![image](https://github.com/user-attachments/assets/9cb758e2-424e-4a75-a6da-d050d6264390)
