### PR TITLE
[ADK-8211] Cache packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ circleci config pack src > orb.yml
 circleci orb validate orb.yml
 
 # For a mutable "dev" version, increment DEV_ORB_VERSION (below) and publish orb.yml.
-DEV_ORB_VERSION=dev:0.5.18
+DEV_ORB_VERSION=dev:0.5.19
 circleci orb publish orb.yml valimail/dependency-manager@$DEV_ORB_VERSION
 
 # For an immutable release, increment ORB_VERSION (below) and publish orb.yml.
 # Note: only GitHub admins of ValiMail can do this currently.
-ORB_VERSION=0.5.18
+ORB_VERSION=0.5.19
 circleci orb publish orb.yml valimail/dependency-manager@$ORB_VERSION
 
 # Update version for tests in .circleci/config.yml

--- a/orb.yml
+++ b/orb.yml
@@ -53,7 +53,7 @@ commands:
             Cleanup old gems so they are not cached
         steps:
             - run:
-                command: bundle exec bundle clean
+                command: rm -rf ~/.bundle/cache/compact_index/gems* && bundle exec bundle clean --force
                 name: Remove old gems
     install-gems:
         description: |

--- a/orb.yml
+++ b/orb.yml
@@ -45,15 +45,15 @@ commands:
                 type: string
         steps:
             - save_cache:
-                key: << parameters.cache-version >>-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
+                key: << parameters.cache-version >>-yarn-packages-{{ checksum "yarn.lock" }}
                 paths:
-                    - << parameters.node-modules-path >>
+                    - ~/.cache/yarn
     clean-gems:
         description: |
             Cleanup old gems so they are not cached
         steps:
             - run:
-                command: rm -rf ~/.bundle/cache/compact_index/gems* && bundle exec bundle clean --force
+                command: bundle exec bundle clean
                 name: Remove old gems
     install-gems:
         description: |
@@ -174,7 +174,7 @@ commands:
                 condition: << parameters.yarn-install >>
                 steps:
                     - run:
-                        command: yarn
+                        command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
                         name: Install node packages
             - when:
                 condition: << parameters.yarn-compile >>
@@ -257,7 +257,7 @@ commands:
         steps:
             - restore_cache:
                 keys:
-                    - << parameters.cache-version >>-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
+                    - << parameters.cache-version >>-yarn-packages-{{ checksum "yarn.lock" }}
                     - << parameters.cache-version >>-packages-{{ .Branch }}
                     - << parameters.cache-version >>-packages-main
                     - << parameters.cache-version >>-packages

--- a/orb.yml
+++ b/orb.yml
@@ -28,7 +28,7 @@ commands:
                 type: string
         steps:
             - save_cache:
-                key: << parameters.cache-version >>-gems-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+                key: << parameters.cache-version >>-gems-{{ checksum "Gemfile.lock" }}
                 paths:
                     - << parameters.bundle-path >>
     cache-packages:
@@ -243,7 +243,7 @@ commands:
         steps:
             - restore_cache:
                 keys:
-                    - << parameters.cache-version >>-gems-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+                    - << parameters.cache-version >>-gems-{{ checksum "Gemfile.lock" }}
                     - << parameters.cache-version >>-gems-{{ .Branch }}
                     - << parameters.cache-version >>-gems-master
                     - << parameters.cache-version >>-gems

--- a/orb.yml
+++ b/orb.yml
@@ -224,16 +224,20 @@ commands:
                 name: Install requirements test
     install-yarn:
         description: |
-            Install nodejs and yarn
+            Install nvm, nodejs and yarn
+        parameters:
+            node-major-version:
+                default: "20"
+                type: string
         steps:
             - run:
                 command: |
                     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
                     echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
                     echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
-                    echo 'nvm install 20' >> $BASH_ENV
-                    echo 'nvm use 20' >> $BASH_ENV
-                name: Install nodejs
+                    echo 'nvm install << parameters.node-major-version >> >> /dev/null' >> $BASH_ENV
+                    echo 'nvm use << parameters.node-major-version >> --silent' >> $BASH_ENV
+                name: Install nvm and nodejs
             - run:
                 command: |
                     sudo apt-get install apt-transport-https

--- a/orb.yml
+++ b/orb.yml
@@ -43,11 +43,15 @@ commands:
                 default: node_modules
                 description: Path to store packages
                 type: string
+            yarn-cache-path:
+                default: ~/.cache/yarn
+                description: Path to cache yarn packages
+                type: string
         steps:
             - save_cache:
                 key: << parameters.cache-version >>-yarn-packages-{{ checksum "yarn.lock" }}
                 paths:
-                    - ~/.cache/yarn
+                    - << parameters.yarn-cache-path >>
     clean-gems:
         description: |
             Cleanup old gems so they are not cached
@@ -158,6 +162,10 @@ commands:
             restore-packages:
                 default: true
                 type: boolean
+            yarn-cache-path:
+                default: ~/.cache/yarn
+                description: Path to cache yarn packages
+                type: string
             yarn-compile:
                 default: false
                 type: boolean
@@ -174,7 +182,7 @@ commands:
                 condition: << parameters.yarn-install >>
                 steps:
                     - run:
-                        command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+                        command: yarn install --frozen-lockfile --cache-folder << parameters.yarn-cache-path >>
                         name: Install node packages
             - when:
                 condition: << parameters.yarn-compile >>
@@ -187,6 +195,7 @@ commands:
                 steps:
                     - cache-packages:
                         cache-version: << parameters.cache-version >>
+                        yarn-cache-path: << parameters.yarn-cache-path >>
     install-postgres-client:
         description: |
             Install PostgreSQL client tools
@@ -245,7 +254,7 @@ commands:
                 keys:
                     - << parameters.cache-version >>-gems-{{ checksum "Gemfile.lock" }}
                     - << parameters.cache-version >>-gems-{{ .Branch }}
-                    - << parameters.cache-version >>-gems-master
+                    - << parameters.cache-version >>-gems-main
                     - << parameters.cache-version >>-gems
     restore-packages:
         description: |

--- a/orb.yml
+++ b/orb.yml
@@ -243,6 +243,7 @@ commands:
         steps:
             - restore_cache:
                 keys:
+                    - << parameters.cache-version >>-gems-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
                     - << parameters.cache-version >>-gems-{{ .Branch }}
                     - << parameters.cache-version >>-gems-master
                     - << parameters.cache-version >>-gems
@@ -258,6 +259,7 @@ commands:
             - restore_cache:
                 keys:
                     - << parameters.cache-version >>-yarn-packages-{{ checksum "yarn.lock" }}
+                    - << parameters.cache-version >>-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
                     - << parameters.cache-version >>-packages-{{ .Branch }}
                     - << parameters.cache-version >>-packages-main
                     - << parameters.cache-version >>-packages

--- a/src/commands/cache-gems.yml
+++ b/src/commands/cache-gems.yml
@@ -14,6 +14,6 @@ parameters:
 
 steps:
   - save_cache:
-      key: << parameters.cache-version >>-gems-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+      key: << parameters.cache-version >>-gems-{{ checksum "Gemfile.lock" }}
       paths:
         - << parameters.bundle-path >>

--- a/src/commands/cache-packages.yml
+++ b/src/commands/cache-packages.yml
@@ -12,8 +12,13 @@ parameters:
     type: string
     default: v1
 
+  yarn-cache-path:
+    description: Path to cache yarn packages
+    type: string
+    default: ~/.cache/yarn
+
 steps:
   - save_cache:
       key: << parameters.cache-version >>-yarn-packages-{{ checksum "yarn.lock" }}
       paths:
-        - ~/.cache/yarn
+        - << parameters.yarn-cache-path >>

--- a/src/commands/cache-packages.yml
+++ b/src/commands/cache-packages.yml
@@ -14,6 +14,6 @@ parameters:
 
 steps:
   - save_cache:
-      key: << parameters.cache-version >>-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      key: << parameters.cache-version >>-yarn-packages-{{ checksum "yarn.lock" }}
       paths:
-        - << parameters.node-modules-path >>
+        - ~/.cache/yarn

--- a/src/commands/clean-gems.yml
+++ b/src/commands/clean-gems.yml
@@ -4,4 +4,4 @@ description: >
 steps:
   - run:
       name: Remove old gems
-      command: bundle exec bundle clean
+      command: rm -rf ~/.bundle/cache/compact_index/gems* && bundle exec bundle clean --force

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -28,6 +28,11 @@ parameters:
     type: boolean
     default: true
 
+  yarn-cache-path:
+    description: Path to cache yarn packages
+    type: string
+    default: ~/.cache/yarn
+
 steps:
   - when:
       condition: << parameters.restore-packages >>
@@ -40,7 +45,7 @@ steps:
       steps:
         - run:
             name: Install node packages
-            command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+            command: yarn install --frozen-lockfile --cache-folder << parameters.yarn-cache-path >>
 
   - when:
       condition: << parameters.yarn-compile >>
@@ -54,3 +59,4 @@ steps:
       steps:
         - cache-packages:
             cache-version: << parameters.cache-version >>
+            yarn-cache-path: << parameters.yarn-cache-path >>

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -40,7 +40,7 @@ steps:
       steps:
         - run:
             name: Install node packages
-            command: yarn
+            command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
 
   - when:
       condition: << parameters.yarn-compile >>

--- a/src/commands/install-yarn.yml
+++ b/src/commands/install-yarn.yml
@@ -1,15 +1,20 @@
 description: >
-  Install nodejs and yarn
+  Install nvm, nodejs and yarn
+
+parameters:
+  node-major-version:
+    type: string
+    default: '20'
 
 steps:
   - run:
-      name: Install nodejs
+      name: Install nvm and nodejs
       command: |
           curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
           echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
           echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
-          echo 'nvm install 20' >> $BASH_ENV
-          echo 'nvm use 20' >> $BASH_ENV
+          echo 'nvm install << parameters.node-major-version >> >> /dev/null' >> $BASH_ENV
+          echo 'nvm use << parameters.node-major-version >> --silent' >> $BASH_ENV
   - run:
       name: Install yarn
       command: |

--- a/src/commands/restore-gems.yml
+++ b/src/commands/restore-gems.yml
@@ -10,7 +10,7 @@ parameters:
 steps:
   - restore_cache:
       keys:
-        - << parameters.cache-version >>-gems-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        - << parameters.cache-version >>-gems-{{ checksum "Gemfile.lock" }}
         - << parameters.cache-version >>-gems-{{ .Branch }}
         - << parameters.cache-version >>-gems-master
         - << parameters.cache-version >>-gems

--- a/src/commands/restore-gems.yml
+++ b/src/commands/restore-gems.yml
@@ -12,5 +12,5 @@ steps:
       keys:
         - << parameters.cache-version >>-gems-{{ checksum "Gemfile.lock" }}
         - << parameters.cache-version >>-gems-{{ .Branch }}
-        - << parameters.cache-version >>-gems-master
+        - << parameters.cache-version >>-gems-main
         - << parameters.cache-version >>-gems

--- a/src/commands/restore-gems.yml
+++ b/src/commands/restore-gems.yml
@@ -10,6 +10,7 @@ parameters:
 steps:
   - restore_cache:
       keys:
+        - << parameters.cache-version >>-gems-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
         - << parameters.cache-version >>-gems-{{ .Branch }}
         - << parameters.cache-version >>-gems-master
         - << parameters.cache-version >>-gems

--- a/src/commands/restore-packages.yml
+++ b/src/commands/restore-packages.yml
@@ -11,6 +11,7 @@ steps:
   - restore_cache:
       keys:
         - << parameters.cache-version >>-yarn-packages-{{ checksum "yarn.lock" }}
+        - << parameters.cache-version >>-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
         - << parameters.cache-version >>-packages-{{ .Branch }}
         - << parameters.cache-version >>-packages-main
         - << parameters.cache-version >>-packages

--- a/src/commands/restore-packages.yml
+++ b/src/commands/restore-packages.yml
@@ -10,7 +10,7 @@ parameters:
 steps:
   - restore_cache:
       keys:
-        - << parameters.cache-version >>-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
+        - << parameters.cache-version >>-yarn-packages-{{ checksum "yarn.lock" }}
         - << parameters.cache-version >>-packages-{{ .Branch }}
         - << parameters.cache-version >>-packages-main
         - << parameters.cache-version >>-packages


### PR DESCRIPTION
## Ticket
https://valimail.atlassian.net/browse/ADK-8211

## Description
- We were missing the cache key for the gems so we added it to the restore and save steps
- The Yarn cache was not used according to the version used (which is 1.22 (stable)), so, we changed the caching strategy to the one proposed by CircleCI (and the correct one for the yarn version we use) for the npm packages when using Yarn as suggested here: https://circleci.com/docs/caching/#basic-example-of-yarn-package-manager-caching

```
~/Sites/dependency-manager-orb  feature/ADK-8211-cache-packages !1  circleci orb validate orb.yml                                                                                                                   ✔  9s  3.2.4   14:53:49
Orb at `orb.yml` is valid.

 ~/Sites/dependency-manager-orb  feature/ADK-8211-cache-packages !1  DEV_ORB_VERSION=dev:0.5.19                                                                                                                           ✔  3.2.4   14:53:59

 ~/Sites/dependency-manager-orb  feature/ADK-8211-cache-packages !1  circleci orb publish orb.yml valimail/dependency-manager@$DEV_ORB_VERSION                                                                            ✔  3.2.4   14:54:06
Once an orb is created it cannot be deleted. Orbs are semver compliant, and each published version is immutable. Publicly released orbs are potential dependencies for other projects.
Therefore, allowing orb deletion would make users susceptible to unexpected loss of functionality.
Orb `valimail/dependency-manager@dev:0.5.19` was published.
Note that your dev label `dev:0.5.19` can be overwritten by anyone in your organization.
Your dev orb will expire in 90 days unless a new version is published on the label `dev:0.5.19`.
Please note that this is an open orb and is world-readable.
```