### PR TITLE
adds a token to display CircleCI job status README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # valimail/dependency-manager - CircleCI Orb
 
-[![CircleCI](https://circleci.com/gh/ValiMail/dependency-manager-orb.svg?style=svg&circle-token=540455df00def7479a3c81c9ab9ac8ab4f810178)](https://circleci.com/gh/ValiMail/dependency-manager-orb)
+[![CircleCI](https://circleci.com/gh/ValiMail/dependency-manager-orb.svg?style=svg&circle-token=CCIPRJ_tyru3cw6Nr8RU8QomXrMM_55946223a8cf052edef39f3f30345c182abc9216)](https://circleci.com/gh/ValiMail/dependency-manager-orb)
 
 CircleCI Orb for managing dependencies like Ruby gems and JS packages.
 


### PR DESCRIPTION
## Description
- Removed the previous git history so as to not display the list of repos using `dependency-manager-orb`
- Adds a new token to display the Circle CI status
- Token is scoped to only status, so no security risk

## Screenshots
List of repos are removed

<img width="716" alt="Screenshot 2024-12-13 at 1 53 57 PM" src="https://github.com/user-attachments/assets/0e1f5c38-c4c9-4810-a48d-3f1ab0d1c4f8" />
