### PR TITLE
[ADK-9100] Replace apt-key with keyring file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ circleci config pack src > orb.yml
 circleci orb validate orb.yml
 
 # For a mutable "dev" version, increment DEV_ORB_VERSION (below) and publish orb.yml.
-DEV_ORB_VERSION=dev:0.5.25
+DEV_ORB_VERSION=dev:0.5.26
 circleci orb publish orb.yml valimail/dependency-manager@$DEV_ORB_VERSION
 
 # For an immutable release, increment ORB_VERSION (below) and publish orb.yml.
 # Note: only GitHub admins of ValiMail can do this currently.
-ORB_VERSION=0.5.25
+ORB_VERSION=0.5.26
 circleci orb publish orb.yml valimail/dependency-manager@$ORB_VERSION
 
 # Update version for tests in .circleci/config.yml

--- a/orb.yml
+++ b/orb.yml
@@ -243,8 +243,9 @@ commands:
             - run:
                 command: |
                     sudo apt-get install curl ca-certificates
-                    curl -k https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-                    sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+                    curl -k https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
+                    CODENAME=$(lsb_release -cs)
+                    echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] https://apt.postgresql.org/pub/repos/apt ${CODENAME}-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
                     sudo apt-get update
                     sudo apt-get install postgresql-client-13
                 name: Install PostgreSQL client tools
@@ -281,8 +282,9 @@ commands:
             - run:
                 command: |
                     sudo apt-get install apt-transport-https
-                    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-                    echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+                    sudo mkdir -m 0755 -p /etc/apt/keyrings
+                    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | sudo tee /etc/apt/keyrings/yarn.gpg >/dev/null
+                    echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
                     sudo apt-get update && sudo apt-get install yarn
                 name: Install yarn
     restore-gems:

--- a/src/commands/install-postgres-client.yml
+++ b/src/commands/install-postgres-client.yml
@@ -6,7 +6,8 @@ steps:
       name: Install PostgreSQL client tools
       command: |
         sudo apt-get install curl ca-certificates
-        curl -k https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+        curl -k https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
+        CODENAME=$(lsb_release -cs)
+        echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] https://apt.postgresql.org/pub/repos/apt ${CODENAME}-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
         sudo apt-get update
         sudo apt-get install postgresql-client-13

--- a/src/commands/install-yarn.yml
+++ b/src/commands/install-yarn.yml
@@ -19,6 +19,7 @@ steps:
       name: Install yarn
       command: |
           sudo apt-get install apt-transport-https
-          curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-          echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+          sudo mkdir -m 0755 -p /etc/apt/keyrings
+          curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | sudo tee /etc/apt/keyrings/yarn.gpg >/dev/null
+          echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
           sudo apt-get update && sudo apt-get install yarn


### PR DESCRIPTION
https://valimail.atlassian.net/browse/ADK-9100
```shell
 ~/Sites/dependency-manager-orb  feature/ADK-…keyring-file  circleci orb validate orb.yml                                                                                                                                 ✔  3.2.4   07:34:00
Orb at `orb.yml` is valid.

 ~/Sites/dependency-manager-orb  feature/ADK-…keyring-file  DEV_ORB_VERSION=dev:0.5.26                                                                                                                                    ✔  3.2.4   07:36:54

 ~/Sites/dependency-manager-orb  feature/ADK-…keyring-file  circleci orb publish orb.yml valimail/dependency-manager@$DEV_ORB_VERSION                                                                                     ✔  3.2.4   07:37:01
Once an orb is created it cannot be deleted. Orbs are semver compliant, and each published version is immutable. Publicly released orbs are potential dependencies for other projects.
Therefore, allowing orb deletion would make users susceptible to unexpected loss of functionality.
Orb `valimail/dependency-manager@dev:0.5.26` was published.
Note that your dev label `dev:0.5.26` can be overwritten by anyone in your organization.
Your dev orb will expire in 90 days unless a new version is published on the label `dev:0.5.26`.
Please note that this is an open orb and is world-readable.
```

https://app.circleci.com/pipelines/github/ValiMail/auth_manager/74711/workflows/ef603771-d42c-479b-9b8a-b8cc0aa292ab/jobs/724314
<img width="3360" height="2076" alt="image" src="https://github.com/user-attachments/assets/d6901b66-f929-42ac-a900-615bc8d58667" />
